### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ tinydream.o: ncnn/build/install/lib/libncnn.a
 	$(CXX) $(TINY_CXXFLAGS) tinydream.cpp -o tinydream.o -c $(LDFLAGS)
 
 unpack: ncnn/build/install/lib/libncnn.a
-	mkdir -p unpack && cd unpack && ar x ../ncnn/build/install/lib/libncnn.a
+	mkdir -p unpack && cd unpack && ar x ../ncnn/build/install/lib/libncnn.a && rm __.SYMDEF
 
 libtinydream.a: tinydream.o unpack $(EXTRA_TARGETS)
 	ar src libtinydream.a tinydream.o $(shell ls unpack/* | xargs echo)


### PR DESCRIPTION
Deletes the SYMDEF file extracted from the former archive to avoid linking implications when creating libstablediffusion.a

The content of libncnn.a is taken to create libstablediffusion.a. However, this results in having two __.SYMDEF files in the new archive. This is tolerated by the linker on Linux because the gnu flavor just picks the first file, the bsd linker however refuses to link if 2 SYMDEF files live in the archive.
So to fix this issue, the SYMDEF file coming from ncnn has to be deleted before the new archive gets created.

Similar to Fix of https://github.com/mudler/LocalAI/issues/1443